### PR TITLE
update Nov 02, 2017

### DIFF
--- a/file_utils/MrFile_Search.m
+++ b/file_utils/MrFile_Search.m
@@ -390,7 +390,7 @@ function [filesFound, nFiles] = MrFile_Search(filename, varargin)
 				filesFound{ii} = newestVersion;
 				dirsFound{ii}  = newestDir;
 			end
-
+			
 	%------------------------------------%
 	% Filter by Version -- Specific      %
 	%------------------------------------%
@@ -563,6 +563,7 @@ function [filesFound, nFiles] = MrFile_Search(filename, varargin)
 		%     'TStart' and 'TEnd'. Otherwise, just pick the file
 		%     associated with 'TStart.
 		%
+		
 		if closest && ~tf_fend && length(filesFound) > 1
 			%
 			% Find the file that starts closest to TSTART
@@ -601,7 +602,7 @@ function [filesFound, nFiles] = MrFile_Search(filename, varargin)
 			fStart     = fStart( iStart:iEnd );
 		end
 	end
-		
+
 %------------------------------------%
 % Directory                          %
 %------------------------------------%

--- a/file_utils/MrFile_nLines.m
+++ b/file_utils/MrFile_nLines.m
@@ -42,7 +42,7 @@ function nLines = MrFile_nLines(file)
 	
 	% Number of lines
 	nLines = 0;
-  line   = '';
+	line   = '';
 
 	while ~feof(fileID) %ischar(line)
 		line   = fgetl(fileID);

--- a/file_utils/MrLogFile.m
+++ b/file_utils/MrLogFile.m
@@ -616,9 +616,8 @@ classdef MrLogFile < handle
 						errText = varargin{1};
 						errID   = '';
 					end
-						
-					assert( isrow(errID),   'ERRID must be a scalar string.' );
-					assert( isrow(errText), 'ERRTEXT must be a scalar string.' );
+					assert( isempty(errID) || isrow(errID), 'ERRID must be a scalar string.' );
+					assert( isrow(errText),                 'ERRTEXT must be a scalar string.' );
 					
 					% Get callstack and calling program
 					%   1 = obj.callstack
@@ -766,9 +765,9 @@ classdef MrLogFile < handle
 			% Write to file (and display).
 			nLines = length(text);
 			for ii = 1 : nLines
-				fprintf( fileID, [ text{ii} '\n' ] );
+				fprintf( fileID, '%s\n', text{ii} );
 				if display
-					fprintf( [ text{ii} '\n' ] );
+					sprintf( '%s\n', text{ii} );
 				end
 			end
 			

--- a/file_utils/mrfprintf.m
+++ b/file_utils/mrfprintf.m
@@ -14,6 +14,7 @@
 %     writes the data to a text file. fprintf uses the encoding scheme specified in
 %     the call to fopen. In place of a fileID returned by fopen, a character array
 %     that names the standard output to which you want the text printed. Options are:
+%       <Object>  -- A MrLogFile object that will add text to a log file via its AddText method
 %       'stderr'  -- Adds error to standard error
 %       'stdout'  -- Adds text to standard output
 %       'logerr'  -- Adds error to standard log file.
@@ -51,6 +52,7 @@
 %   2015-08-09      Written by Matthew Argall
 %   2016-04-01      Removed the "stdlog" and "logout" options. - MRA
 %   2016-10-01      Cell arrays may be given. - MRA
+%   2017-08-03      FileID can be a MrLogFile object. - MRA
 %
 function [] = mrfprintf( varargin )
 	%
@@ -183,6 +185,12 @@ function [] = mrfprintf( varargin )
 				fprintf( msg );
 			end
 		end
+	
+%------------------------------------%
+% MrLogFile object                   %
+%------------------------------------%
+	elseif isa(varargin{1}, 'MrLogFile')
+		varargin{1}.AddText( sprintf(varargin{2:end}) );
 
 %------------------------------------%
 % Regular fprinf                     %


### PR DESCRIPTION
  - FIX: MrLogFile- AddErr accepts row or column of error IDs; AddText applies format codes to text properly
  - ADD: mrfprintf- Accepts MrLogFile objects as input
  - FIX: MrTimeParser- %c now abbreviates month names; standardize inputs by converting scalar strings to a cell; keep characters after last metacharacter
  - FIX: documentation and formatting